### PR TITLE
Use imcompatible, but correct memsize_of of Ruby 2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 example.out
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.0
+  - 2.1
+  - 2.2
 script: 'bundle exec rake test'

--- a/lib/memprof2.rb
+++ b/lib/memprof2.rb
@@ -58,7 +58,15 @@ class Memprof2
       next if (@trace  and @trace !~ file)
       next if (@ignore and @ignore =~ file)
       line = ObjectSpace.allocation_sourceline(o)
-      memsize = ObjectSpace.memsize_of(o) + @rvalue_size
+      if RUBY_VERSION >= "2.2.0"
+        # Ruby 2.2.0 takes into account sizeof(RVALUE)
+        # https://bugs.ruby-lang.org/issues/8984
+        memsize = ObjectSpace.memsize_of(o)
+      else
+        # Ruby < 2.2.0 does not have ways to get memsize correctly, but let me make a bid as much as possible
+        # https://twitter.com/sonots/status/544334978515869698
+        memsize = ObjectSpace.memsize_of(o) + @rvalue_size
+      end
       memsize = @rvalue_size if memsize > 100_000_000_000 # compensate for API bug
       klass = o.class.name rescue "BasicObject"
       location = "#{file}:#{line}:#{klass}"


### PR DESCRIPTION
See
- https://bugs.ruby-lang.org/issues/8984
- https://twitter.com/sonots/status/544334978515869698
