### PR TITLE
Proposal:  Memprof2.run_with_report method

### DIFF
--- a/lib/memprof2.rb
+++ b/lib/memprof2.rb
@@ -26,6 +26,14 @@ class Memprof2
       report(opts)
       ObjectSpace.trace_object_allocations_clear
     end
+
+    def run_with_report(opts = {}, &block)
+      start
+      yield
+      report(opts)
+    ensure
+      stop
+    end
   end
 
   def report(opts={})

--- a/test/test_memprof2.rb
+++ b/test/test_memprof2.rb
@@ -50,4 +50,12 @@ class TestMemprof2 < Test::Unit::TestCase
     assert_match("test/test_memprof2.rb:46:String\n", File.read(opts_bang[:out]))
     assert_match("", File.read(opts[:out]))
   end
+
+  def test_run_with_result
+    opts = {out: "tmp/test_run_with_report.out"}
+    Memprof2.run_with_report(opts) do
+      a = "abc"
+    end
+    assert_match("test/test_memprof2.rb:57:String\n", File.read(opts[:out]))
+  end
 end


### PR DESCRIPTION
Memprof2.run_with_report is shorthand method that start, report, stop.
like [`MemoryProfiler.report`](https://github.com/SamSaffron/memory_profiler#usage) .